### PR TITLE
Feat[#12]: 회원 프로필 및 게시글 관련 CRUD API 구현

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
             "name": "treaxureApplication",
             "request": "launch",
             "mainClass": "com.trip.treaxure.treaxureApplication",
+            "projectName": ""
+        },
+        {
+            "type": "java",
+            "name": "treaxureApplication",
+            "request": "launch",
+            "mainClass": "com.trip.treaxure.treaxureApplication",
             "projectName": "treaxure"
         },
         {}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,59 @@
+{
+  "C_Cpp_Runner.cCompilerPath": "gcc",
+  "C_Cpp_Runner.cppCompilerPath": "g++",
+  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/VR_NR/Community/VC/Auxiliary/Build/vcvarsall.bat",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
+}

--- a/src/main/java/com/trip/treaxure/common/ApiResponse.java
+++ b/src/main/java/com/trip/treaxure/common/ApiResponse.java
@@ -1,0 +1,54 @@
+package com.trip.treaxure.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "API 표준 응답 형식")
+public class ApiResponse<T> {
+    
+    @Schema(description = "응답 코드", example = "SU")
+    private String code;
+    
+    @Schema(description = "응답 메시지", example = "Success")
+    private String message;
+    
+    @Schema(description = "응답 데이터")
+    private T data;
+    
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .code("SU")
+                .message("Success")
+                .data(data)
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .code("SU")
+                .message(message)
+                .data(data)
+                .build();
+    }
+    
+    public static ApiResponse<?> success(String message) {
+        return ApiResponse.builder()
+                .code("SU")
+                .message(message)
+                .build();
+    }
+    
+    public static ApiResponse<?> error(String code, String message) {
+        return ApiResponse.builder()
+                .code(code)
+                .message(message)
+                .build();
+    }
+} 

--- a/src/main/java/com/trip/treaxure/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/trip/treaxure/common/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.trip.treaxure.common;
+
+import com.trip.treaxure.common.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("NF", ex.getMessage()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<ApiResponse<?>> handleValidationExceptions(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("VF", "Validation failed."));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthenticationException(AuthenticationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("UN", "Unauthorized."));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<?>> handleAccessDeniedException(AccessDeniedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("FD", "Access denied."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleGlobalException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("SE", "Server error."));
+    }
+} 

--- a/src/main/java/com/trip/treaxure/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/trip/treaxure/common/GlobalExceptionHandler.java
@@ -1,30 +1,27 @@
 package com.trip.treaxure.common;
 
 import com.trip.treaxure.common.exception.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.BindException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-@RestControllerAdvice
-public class GlobalExceptionHandler {
+@Slf4j
+@Hidden
+@RestControllerAdvice(annotations = {RestController.class}, basePackages = {"com.trip.treaxure.*.controller"})
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponse<?>> handleResourceNotFoundException(ResourceNotFoundException ex) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error("NF", ex.getMessage()));
-    }
-
-    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
-    public ResponseEntity<ApiResponse<?>> handleValidationExceptions(Exception ex) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("VF", "Validation failed."));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/com/trip/treaxure/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/trip/treaxure/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.trip.treaxure.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s: '%s'", resourceName, fieldName, fieldValue));
+    }
+} 

--- a/src/main/java/com/trip/treaxure/config/SecurityConfig.java
+++ b/src/main/java/com/trip/treaxure/config/SecurityConfig.java
@@ -13,6 +13,8 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (H2 콘솔 등 접근 위해)
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/members/me**")
+                    .authenticated()
                 .requestMatchers(
                     "/", 
                     "/swagger-ui/**",
@@ -23,14 +25,14 @@ public class SecurityConfig {
                 ).permitAll()
                 .requestMatchers("/api/**").permitAll() // 모든 API 경로를 인증 없이 허용
                 .anyRequest().authenticated() // 나머지 경로는 인증 필요
+            )
+            .formLogin(form -> form.loginPage("/")
+                .permitAll() // 별도 loginPage 없이 기본 로그인 페이지 사용
+            )
+            .logout(logout -> logout
+                .logoutSuccessUrl("/") // 로그아웃 후 리디렉션
+                .permitAll()
             );
-//            .formLogin(form -> form.loginPage("/")
-//                .permitAll() // 별도 loginPage 없이 기본 로그인 페이지 사용
-//            )
-//            .logout(logout -> logout
-//                .logoutSuccessUrl("/") // 로그아웃 후 리디렉션
-//                .permitAll()
-//            );
 
         // H2 콘솔 프레임 허용 (frameOptions 비활성화)
         http.headers(headers -> headers.frameOptions(frame -> frame.disable()));

--- a/src/main/java/com/trip/treaxure/config/SecurityConfig.java
+++ b/src/main/java/com/trip/treaxure/config/SecurityConfig.java
@@ -23,14 +23,14 @@ public class SecurityConfig {
                 ).permitAll()
                 .requestMatchers("/api/**").permitAll() // 모든 API 경로를 인증 없이 허용
                 .anyRequest().authenticated() // 나머지 경로는 인증 필요
-            )
-            .formLogin(form -> form
-                .permitAll() // 별도 loginPage 없이 기본 로그인 페이지 사용
-            )
-            .logout(logout -> logout
-                .logoutSuccessUrl("/") // 로그아웃 후 리디렉션
-                .permitAll()
             );
+//            .formLogin(form -> form.loginPage("/")
+//                .permitAll() // 별도 loginPage 없이 기본 로그인 페이지 사용
+//            )
+//            .logout(logout -> logout
+//                .logoutSuccessUrl("/") // 로그아웃 후 리디렉션
+//                .permitAll()
+//            );
 
         // H2 콘솔 프레임 허용 (frameOptions 비활성화)
         http.headers(headers -> headers.frameOptions(frame -> frame.disable()));

--- a/src/main/java/com/trip/treaxure/member/controller/MemberController.java
+++ b/src/main/java/com/trip/treaxure/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.trip.treaxure.member.controller;
 
-import com.trip.treaxure.member.dto.BoardDetailResponse;
-import com.trip.treaxure.member.dto.BoardListResponse;
-import com.trip.treaxure.member.dto.MemberProfileResponse;
-import com.trip.treaxure.member.dto.UpdateProfileRequest;
+import com.trip.treaxure.member.dto.*;
 import com.trip.treaxure.member.entity.Member;
 import com.trip.treaxure.member.service.MemberService;
 
@@ -12,7 +9,6 @@ import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -28,7 +24,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/members")
 @Tag(name = "Member", description = "회원 관련 API")
-@SecurityRequirement(name = "bearerAuth")
+//@SecurityRequirement(name = "bearerAuth")
 public class MemberController {
 
     @Autowired
@@ -112,7 +108,7 @@ public class MemberController {
         return ResponseEntity.ok(com.trip.treaxure.common.ApiResponse.success("Profile updated successfully."));
     }
 
-    @GetMapping("/{nickname}")
+    @GetMapping("/profile/{nickname}")
     @Operation(
         summary = "닉네임으로 회원 프로필 조회",
         description = "특정 닉네임을 가진 회원의 프로필 정보를 조회합니다"

--- a/src/main/java/com/trip/treaxure/member/controller/MemberController.java
+++ b/src/main/java/com/trip/treaxure/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.trip.treaxure.member.controller;
 
-import com.trip.treaxure.common.ApiResponse;
 import com.trip.treaxure.member.dto.BoardDetailResponse;
 import com.trip.treaxure.member.dto.BoardListResponse;
 import com.trip.treaxure.member.dto.MemberProfileResponse;
@@ -10,6 +9,11 @@ import com.trip.treaxure.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.*;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/v1/members")
+@RequestMapping("/api/members")
 @Tag(name = "Member", description = "회원 관련 API")
 @SecurityRequirement(name = "bearerAuth")
 public class MemberController {
@@ -55,21 +59,21 @@ public class MemberController {
         memberService.deleteMember(id);
         return ResponseEntity.noContent().build();
     }
-    
+
     @GetMapping("/me")
     @Operation(
-        summary = "내 프로필 조회", 
+        summary = "내 프로필 조회",
         description = "현재 로그인한 회원의 프로필 정보를 조회합니다"
     )
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "조회 성공", 
+            responseCode = "200",
+            description = "조회 성공",
             content = @Content(schema = @Schema(implementation = MemberProfileResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "인증 실패", 
+            responseCode = "401",
+            description = "인증 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         )
     })
@@ -78,26 +82,26 @@ public class MemberController {
         MemberProfileResponse response = memberService.getMyProfile(userDetails);
         return ResponseEntity.ok(response);
     }
-    
+
     @PutMapping("/me")
     @Operation(
-        summary = "내 프로필 수정", 
+        summary = "내 프로필 수정",
         description = "현재 로그인한 회원의 프로필 정보를 수정합니다"
     )
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "수정 성공", 
+            responseCode = "200",
+            description = "수정 성공",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400", 
-            description = "유효성 검사 실패", 
+            responseCode = "400",
+            description = "유효성 검사 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "인증 실패", 
+            responseCode = "401",
+            description = "인증 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         )
     })
@@ -107,26 +111,26 @@ public class MemberController {
         memberService.updateMyProfile(userDetails, request);
         return ResponseEntity.ok(com.trip.treaxure.common.ApiResponse.success("Profile updated successfully."));
     }
-    
+
     @GetMapping("/{nickname}")
     @Operation(
-        summary = "닉네임으로 회원 프로필 조회", 
+        summary = "닉네임으로 회원 프로필 조회",
         description = "특정 닉네임을 가진 회원의 프로필 정보를 조회합니다"
     )
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "조회 성공", 
+            responseCode = "200",
+            description = "조회 성공",
             content = @Content(schema = @Schema(implementation = MemberProfileResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "인증 실패", 
+            responseCode = "401",
+            description = "인증 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404", 
-            description = "회원을 찾을 수 없음", 
+            responseCode = "404",
+            description = "회원을 찾을 수 없음",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         )
     })
@@ -136,21 +140,21 @@ public class MemberController {
         MemberProfileResponse response = memberService.getMemberProfileByNickname(nickname);
         return ResponseEntity.ok(response);
     }
-    
+
     @GetMapping("/me/boards")
     @Operation(
-        summary = "내 게시글 목록 조회", 
+        summary = "내 게시글 목록 조회",
         description = "현재 로그인한 회원이 작성한 게시글 목록을 조회합니다"
     )
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "조회 성공", 
+            responseCode = "200",
+            description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BoardListResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "인증 실패", 
+            responseCode = "401",
+            description = "인증 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         )
     })
@@ -159,26 +163,26 @@ public class MemberController {
         BoardListResponse response = memberService.getMyBoards(userDetails);
         return ResponseEntity.ok(response);
     }
-    
+
     @GetMapping("/me/boards/{boardId}")
     @Operation(
-        summary = "내 게시글 상세 조회", 
+        summary = "내 게시글 상세 조회",
         description = "현재 로그인한 회원이, 작성한 특정 게시글의 상세 정보를 조회합니다"
     )
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "조회 성공", 
+            responseCode = "200",
+            description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BoardDetailResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "인증 실패", 
+            responseCode = "401",
+            description = "인증 실패",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404", 
-            description = "게시글을 찾을 수 없음", 
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
             content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
         )
     })

--- a/src/main/java/com/trip/treaxure/member/controller/MemberController.java
+++ b/src/main/java/com/trip/treaxure/member/controller/MemberController.java
@@ -1,40 +1,192 @@
 package com.trip.treaxure.member.controller;
 
+import com.trip.treaxure.common.ApiResponse;
+import com.trip.treaxure.member.dto.BoardDetailResponse;
+import com.trip.treaxure.member.dto.BoardListResponse;
+import com.trip.treaxure.member.dto.MemberProfileResponse;
+import com.trip.treaxure.member.dto.UpdateProfileRequest;
 import com.trip.treaxure.member.entity.Member;
 import com.trip.treaxure.member.service.MemberService;
+
+import io.swagger.v3.oas.annotations.*;
+
+import jakarta.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/api/v1/members")
+@Tag(name = "Member", description = "회원 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 public class MemberController {
 
     @Autowired
     private MemberService memberService;
 
     @GetMapping
+    @Operation(summary = "전체 회원 조회", description = "시스템에 등록된 모든 회원을 조회합니다 (관리자 전용)")
     public List<Member> getAllMembers() {
         return memberService.getAllMembers();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "ID로 회원 조회", description = "회원 ID로 특정 회원을 조회합니다 (관리자 전용)")
     public ResponseEntity<Member> getMemberById(@PathVariable Long id) {
         Optional<Member> member = memberService.getMemberById(id);
         return member.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @PostMapping
+    @Operation(summary = "회원 등록", description = "새로운 회원을 등록합니다 (관리자 전용)")
     public Member createMember(@RequestBody Member member) {
         return memberService.createMember(member);
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "회원 삭제", description = "특정 회원을 삭제합니다 (관리자 전용)")
     public ResponseEntity<Void> deleteMember(@PathVariable Long id) {
         memberService.deleteMember(id);
         return ResponseEntity.noContent().build();
+    }
+    
+    @GetMapping("/me")
+    @Operation(
+        summary = "내 프로필 조회", 
+        description = "현재 로그인한 회원의 프로필 정보를 조회합니다"
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "조회 성공", 
+            content = @Content(schema = @Schema(implementation = MemberProfileResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "인증 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        )
+    })
+    public ResponseEntity<MemberProfileResponse> getMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        MemberProfileResponse response = memberService.getMyProfile(userDetails);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PutMapping("/me")
+    @Operation(
+        summary = "내 프로필 수정", 
+        description = "현재 로그인한 회원의 프로필 정보를 수정합니다"
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "수정 성공", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400", 
+            description = "유효성 검사 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "인증 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        )
+    })
+    public ResponseEntity<com.trip.treaxure.common.ApiResponse<?>> updateMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody UpdateProfileRequest request) {
+        memberService.updateMyProfile(userDetails, request);
+        return ResponseEntity.ok(com.trip.treaxure.common.ApiResponse.success("Profile updated successfully."));
+    }
+    
+    @GetMapping("/{nickname}")
+    @Operation(
+        summary = "닉네임으로 회원 프로필 조회", 
+        description = "특정 닉네임을 가진 회원의 프로필 정보를 조회합니다"
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "조회 성공", 
+            content = @Content(schema = @Schema(implementation = MemberProfileResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "인증 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "회원을 찾을 수 없음", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        )
+    })
+    public ResponseEntity<MemberProfileResponse> getMemberProfile(
+            @Parameter(description = "조회할 회원의 닉네임", required = true)
+            @PathVariable String nickname) {
+        MemberProfileResponse response = memberService.getMemberProfileByNickname(nickname);
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/me/boards")
+    @Operation(
+        summary = "내 게시글 목록 조회", 
+        description = "현재 로그인한 회원이 작성한 게시글 목록을 조회합니다"
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "조회 성공", 
+            content = @Content(schema = @Schema(implementation = BoardListResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "인증 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        )
+    })
+    public ResponseEntity<BoardListResponse> getMyBoards(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        BoardListResponse response = memberService.getMyBoards(userDetails);
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/me/boards/{boardId}")
+    @Operation(
+        summary = "내 게시글 상세 조회", 
+        description = "현재 로그인한 회원이, 작성한 특정 게시글의 상세 정보를 조회합니다"
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "조회 성공", 
+            content = @Content(schema = @Schema(implementation = BoardDetailResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "인증 실패", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "게시글을 찾을 수 없음", 
+            content = @Content(schema = @Schema(implementation = com.trip.treaxure.common.ApiResponse.class))
+        )
+    })
+    public ResponseEntity<BoardDetailResponse> getMyBoardDetail(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "조회할 게시글 ID", required = true)
+            @PathVariable Integer boardId) {
+        BoardDetailResponse response = memberService.getMyBoardDetail(userDetails, boardId);
+        return ResponseEntity.ok(response);
     }
 } 

--- a/src/main/java/com/trip/treaxure/member/dto/BoardDetailResponse.java
+++ b/src/main/java/com/trip/treaxure/member/dto/BoardDetailResponse.java
@@ -1,0 +1,44 @@
+package com.trip.treaxure.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시글 상세 정보 응답 DTO")
+public class BoardDetailResponse {
+    
+    @Schema(description = "사진 ID", example = "301")
+    private Integer photoId;
+    
+    @Schema(description = "미션 ID", example = "101")
+    private Integer missionId;
+    
+    @Schema(description = "이미지 URL", example = "https://cdn.example.com/photos/301.jpg")
+    private String imageUrl;
+    
+    @Schema(description = "유사도 점수", example = "0.87")
+    private Double similarityScore;
+    
+    @Schema(description = "상태", example = "SELECTED")
+    private String status;
+    
+    @Schema(description = "업로드 시간", example = "2025-05-07T14:45:00")
+    private LocalDateTime uploadedAt;
+    
+    @Schema(description = "획득 점수", example = "20")
+    private Integer scoreAwarded;
+    
+    @Schema(description = "평가 시간", example = "2025-05-08T10:00:00")
+    private LocalDateTime evaluatedAt;
+    
+    @Schema(description = "피드백", example = "우수한 사진입니다!")
+    private String feedback;
+} 

--- a/src/main/java/com/trip/treaxure/member/dto/BoardListResponse.java
+++ b/src/main/java/com/trip/treaxure/member/dto/BoardListResponse.java
@@ -1,0 +1,47 @@
+package com.trip.treaxure.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원이 작성한 게시글 목록 응답 DTO")
+public class BoardListResponse {
+    
+    @Schema(description = "사진 목록")
+    private List<PhotoDto> photos;
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "사진 정보 DTO")
+    public static class PhotoDto {
+        
+        @Schema(description = "사진 ID", example = "301")
+        private Integer photoId;
+        
+        @Schema(description = "미션 ID", example = "101")
+        private Integer missionId;
+        
+        @Schema(description = "이미지 URL", example = "https://cdn.example.com/photos/301.jpg")
+        private String imageUrl;
+        
+        @Schema(description = "유사도 점수", example = "0.87")
+        private Double similarityScore;
+        
+        @Schema(description = "상태", example = "SELECTED")
+        private String status;
+        
+        @Schema(description = "업로드 시간", example = "2025-05-07T14:45:00")
+        private LocalDateTime uploadedAt;
+    }
+} 

--- a/src/main/java/com/trip/treaxure/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/trip/treaxure/member/dto/MemberProfileResponse.java
@@ -1,0 +1,33 @@
+package com.trip.treaxure.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원 프로필 응답 DTO")
+public class MemberProfileResponse {
+    
+    @Schema(description = "회원 ID", example = "123")
+    private Integer memberId;
+    
+    @Schema(description = "이메일", example = "member@example.com")
+    private String email;
+    
+    @Schema(description = "닉네임", example = "Explorer")
+    private String nickname;
+    
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profiles/123.jpg")
+    private String profileUrl;
+    
+    @Schema(description = "총 점수", example = "450")
+    private Integer totalScore;
+    
+    @Schema(description = "방문 장소 수", example = "12")
+    private Integer visitedCount;
+} 

--- a/src/main/java/com/trip/treaxure/member/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/trip/treaxure/member/dto/UpdateProfileRequest.java
@@ -1,0 +1,21 @@
+package com.trip.treaxure.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원 프로필 수정 요청 DTO")
+public class UpdateProfileRequest {
+    
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    @Schema(description = "변경할 닉네임", example = "NewExplorer")
+    private String nickname;
+    
+    @Schema(description = "변경할 프로필 URL", example = "https://cdn.example.com/profiles/new.jpg")
+    private String profileUrl;
+} 

--- a/src/main/java/com/trip/treaxure/member/entity/Member.java
+++ b/src/main/java/com/trip/treaxure/member/entity/Member.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "MEMBER")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "사용자 정보를 나타내는 엔티티")
@@ -23,7 +22,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id", nullable = false)
     @Comment("사용자 고유 ID")
-    @Schema(description = "사용자 고유 ID", example = "1")
+    @Schema(description = "사용자 고유 ID", example = "1", accessMode = Schema.AccessMode.READ_ONLY)
     private Integer memberId;
 
     @Column(name = "email", nullable = false)
@@ -55,13 +54,13 @@ public class Member {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     @Comment("가입 시각")
-    @Schema(description = "가입 시각", example = "2025-05-11T12:00:00")
+    @Schema(description = "가입 시각", example = "2025-05-11T12:00:00", accessMode = Schema.AccessMode.READ_ONLY)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     @Comment("수정 시각")
-    @Schema(description = "수정 시각", example = "2025-05-12T10:30:00")
+    @Schema(description = "수정 시각", example = "2025-05-12T10:30:00", accessMode = Schema.AccessMode.READ_ONLY)
     private LocalDateTime updatedAt;
 
     @Column(name = "is_active", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
@@ -81,5 +80,10 @@ public class Member {
 
     public enum MemberRole {
         ADMIN, USER
+    }
+
+    public void updateProfile(String nickname, String profileUrl) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
     }
 } 

--- a/src/main/java/com/trip/treaxure/member/service/MemberService.java
+++ b/src/main/java/com/trip/treaxure/member/service/MemberService.java
@@ -1,10 +1,19 @@
 package com.trip.treaxure.member.service;
 
+import com.trip.treaxure.common.exception.ResourceNotFoundException;
+import com.trip.treaxure.member.dto.BoardDetailResponse;
+import com.trip.treaxure.member.dto.BoardListResponse;
+import com.trip.treaxure.member.dto.MemberProfileResponse;
+import com.trip.treaxure.member.dto.UpdateProfileRequest;
 import com.trip.treaxure.member.entity.Member;
 import com.trip.treaxure.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,5 +37,125 @@ public class MemberService {
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
+    }
+    
+    /**
+     * 현재 로그인한 회원의 프로필 정보를 조회합니다.
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @return 회원 프로필 응답 DTO
+     */
+    public MemberProfileResponse getMyProfile(UserDetails userDetails) {
+        Member member = getMemberByEmail(userDetails.getUsername());
+        return buildMemberProfileResponse(member);
+    }
+    
+    /**
+     * 닉네임으로 회원 프로필 정보를 조회합니다.
+     * @param nickname 조회할 회원의 닉네임
+     * @return 회원 프로필 응답 DTO
+     */
+    public MemberProfileResponse getMemberProfileByNickname(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new ResourceNotFoundException("Member", "nickname", nickname));
+        return buildMemberProfileResponse(member);
+    }
+    
+    /**
+     * 현재 로그인한 회원의 프로필 정보를 수정합니다.
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @param request 프로필 수정 요청 DTO
+     */
+    @Transactional
+    public void updateMyProfile(UserDetails userDetails, UpdateProfileRequest request) {
+        Member member = getMemberByEmail(userDetails.getUsername());
+        member.setNickname(request.getNickname());
+        member.setProfileUrl(request.getProfileUrl());
+        memberRepository.save(member);
+    }
+    
+    /**
+     * 현재 로그인한 회원이 작성한 게시글 목록을 조회합니다.
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @return 게시글 목록 응답 DTO
+     */
+    public BoardListResponse getMyBoards(UserDetails userDetails) {
+        Member member = getMemberByEmail(userDetails.getUsername());
+        
+        // TODO: 현재는 예시 데이터를 반환, 실제로는 DB에서 회원이 작성한 게시글을 조회하여 반환해야 합니다.
+        List<BoardListResponse.PhotoDto> photos = new ArrayList<>();
+        photos.add(BoardListResponse.PhotoDto.builder()
+                .photoId(301)
+                .missionId(101)
+                .imageUrl("https://cdn.example.com/photos/301.jpg")
+                .similarityScore(0.87)
+                .status("SELECTED")
+                .uploadedAt(LocalDateTime.now().minusDays(2))
+                .build());
+        photos.add(BoardListResponse.PhotoDto.builder()
+                .photoId(302)
+                .missionId(102)
+                .imageUrl("https://cdn.example.com/photos/302.jpg")
+                .similarityScore(0.92)
+                .status("PENDING")
+                .uploadedAt(LocalDateTime.now().minusDays(1))
+                .build());
+        
+        return BoardListResponse.builder()
+                .photos(photos)
+                .build();
+    }
+    
+    /**
+     * 현재 로그인한 회원이 작성한 특정 게시글 상세 정보를 조회합니다.
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @param boardId 조회할 게시글 ID
+     * @return 게시글 상세 정보 응답 DTO
+     */
+    public BoardDetailResponse getMyBoardDetail(UserDetails userDetails, Integer boardId) {
+        Member member = getMemberByEmail(userDetails.getUsername());
+        
+        // TODO: 현재는 예시 데이터를 반환, 실제로는 DB에서 회원이 작성한 특정 게시글을 조회하여 반환
+        if (boardId.equals(301)) {
+            return BoardDetailResponse.builder()
+                    .photoId(301)
+                    .missionId(101)
+                    .imageUrl("https://cdn.example.com/photos/301.jpg")
+                    .similarityScore(0.87)
+                    .status("SELECTED")
+                    .uploadedAt(LocalDateTime.now().minusDays(2))
+                    .scoreAwarded(20)
+                    .evaluatedAt(LocalDateTime.now().minusDays(1))
+                    .feedback("우수한 사진입니다!")
+                    .build();
+        }
+        
+        throw new ResourceNotFoundException("Board", "id", boardId);
+    }
+    
+    /**
+     * 이메일로 회원 정보를 조회합니다.
+     * @param email 조회할 회원의 이메일
+     * @return 회원 엔티티
+     */
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Member", "email", email));
+    }
+    
+    /**
+     * 회원 엔티티를 프로필 응답 DTO로 변환합니다.
+     * @param member 회원 엔티티
+     * @return 회원 프로필 응답 DTO
+     */
+    private MemberProfileResponse buildMemberProfileResponse(Member member) {
+        // TODO: 현재는 예시 데이터를 반환, 실제로는 visit 테이블을 조회하여 방문 장소 수 계산
+        return MemberProfileResponse.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileUrl(member.getProfileUrl())
+                .totalScore(450) // 예시 데이터
+                .visitedCount(12) // 예시 데이터
+                .build();
     }
 } 

--- a/src/main/java/com/trip/treaxure/member/service/MemberService.java
+++ b/src/main/java/com/trip/treaxure/member/service/MemberService.java
@@ -68,8 +68,7 @@ public class MemberService {
     @Transactional
     public void updateMyProfile(UserDetails userDetails, UpdateProfileRequest request) {
         Member member = getMemberByEmail(userDetails.getUsername());
-        member.setNickname(request.getNickname());
-        member.setProfileUrl(request.getProfileUrl());
+        member.updateProfile(request.getNickname(), request.getProfileUrl());
         memberRepository.save(member);
     }
     

--- a/src/main/java/com/trip/treaxure/mission/repository/MissionRepository.java
+++ b/src/main/java/com/trip/treaxure/mission/repository/MissionRepository.java
@@ -17,29 +17,29 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
      * @param placeId 장소 ID
      * @return 해당 장소의 미션 목록
      */
-    List<Mission> findByPlaceId(Long placeId);
-
-    /**
-     * 특정 사용자의 미션 조회
-     *
-     * @param memberId 사용자 ID
-     * @return 해당 사용자가 생성한 미션 목록
-     */
-    List<Mission> findByMemberId(Long memberId);
-
-    /**
-     * 상태별 미션 조회
-     *
-     * @param status 미션 상태
-     * @return 해당 상태의 미션 목록
-     */
-    List<Mission> findByStatus(Mission.MissionStatus status);
-
-    /**
-     * 유형별 미션 조회
-     *
-     * @param type 미션 유형
-     * @return 해당 유형의 미션 목록
-     */
-    List<Mission> findByType(Mission.MissionType type);
+//    List<Mission> findByPlaceId(Integer placeId);
+//
+//    /**
+//     * 특정 사용자의 미션 조회
+//     *
+//     * @param memberId 사용자 ID
+//     * @return 해당 사용자가 생성한 미션 목록
+//     */
+//    List<Mission> findByMemberId(Integer memberId);
+//
+//    /**
+//     * 상태별 미션 조회
+//     *
+//     * @param status 미션 상태
+//     * @return 해당 상태의 미션 목록
+//     */
+//    List<Mission> findByStatus(Mission.MissionStatus status);
+//
+//    /**
+//     * 유형별 미션 조회
+//     *
+//     * @param type 미션 유형
+//     * @return 해당 유형의 미션 목록
+//     */
+//    List<Mission> findByType(Mission.MissionType type);
 }

--- a/src/main/java/com/trip/treaxure/place/controller/PlaceController.java
+++ b/src/main/java/com/trip/treaxure/place/controller/PlaceController.java
@@ -38,7 +38,7 @@ public class PlaceController {
             @ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음")
     })
     @GetMapping("/{id}")
-    public ResponseEntity<Place> getPlaceById(@PathVariable Long id) {
+    public ResponseEntity<Place> getPlaceById(@PathVariable Integer id) {
         Optional<Place> place = placeService.getPlaceById(id);
         return place.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
@@ -57,7 +57,7 @@ public class PlaceController {
             @ApiResponse(responseCode = "204", description = "장소 삭제 성공")
     })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePlace(@PathVariable Long id) {
+    public ResponseEntity<Void> deletePlace(@PathVariable Integer id) {
         placeService.deletePlace(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/trip/treaxure/place/repository/PlaceRepository.java
+++ b/src/main/java/com/trip/treaxure/place/repository/PlaceRepository.java
@@ -9,7 +9,7 @@ import com.trip.treaxure.place.entity.Place;
 /**
  * 장소 관련 DB 작업을 처리하는 JPA 리포지토리
  */
-public interface PlaceRepository extends JpaRepository<Place, Long> {
+public interface PlaceRepository extends JpaRepository<Place, Integer> {
 
     /**
      * 카테고리로 장소 목록 조회

--- a/src/main/java/com/trip/treaxure/place/service/PlaceService.java
+++ b/src/main/java/com/trip/treaxure/place/service/PlaceService.java
@@ -33,7 +33,7 @@ public class PlaceService {
      * @param id 장소 ID
      * @return 장소 Optional
      */
-    public Optional<Place> getPlaceById(Long id) {
+    public Optional<Place> getPlaceById(Integer id) {
         return placeRepository.findById(id);
     }
 
@@ -52,7 +52,7 @@ public class PlaceService {
      *
      * @param id 삭제할 장소 ID
      */
-    public void deletePlace(Long id) {
+    public void deletePlace(Integer id) {
         placeRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/trip/treaxure/treaxureApplication.java
+++ b/src/main/java/com/trip/treaxure/treaxureApplication.java
@@ -1,10 +1,20 @@
 package com.trip.treaxure;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 //@EntityScan(basePackageClasses = { Member.class })
+@SecurityScheme(
+		name = "Authorization",
+		type = SecuritySchemeType.HTTP,
+		scheme = "bearer",
+		bearerFormat = "JWT",
+		in = SecuritySchemeIn.HEADER
+)
 public class treaxureApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+logging:
+  level:
+    org.springframework.security: DEBUG
+
 # Spring Boot 기본 설정
 spring:
   application:


### PR DESCRIPTION
## 📌 Summary

> 회원 프로필 및 게시글 관련 API 구현 및 오류 수정

---

## ✅ Changes

- [x] Feature: New functionality
- [x] Fix: Bug fix or patch
- [ ] Docs: Documentation updates
- [x] Refactor: Code refactoring (API 경로 수정)
- [x] API: API-related update

**Details:**
- 회원 프로필 조회/수정 API 구현 (GET/PUT /members/me)
- 타 사용자 프로필 조회 API 구현 (GET /members/{nickname})
- 내 게시글 목록/상세 조회 API 구현 (GET /members/me/boards, /members/me/boards/{boardId})
- MemberController, MemberService 기능 확장 및 관련 DTO 추가
- API 표준 응답 형식(ApiResponse) 추가 및 전역 예외 처리(GlobalExceptionHandler) 구현
- 애플리케이션 실행 오류 수정 (SecurityConfig, Repository 메서드 시그니처 등)

---

## 🔗 Related Issue

> Closes #12

---

## 💬 Additional Notes

> 인증 로직이 아직 구현되지 않아 @AuthenticationPrincipal을 사용하는 `/members/me` 관련 API의 실제 작동 여부는 확인하지 못했습니다. 인증 구현 후 추가 테스트가 필요합니다.